### PR TITLE
Enabled editing multiple records on the same page.

### DIFF
--- a/View/Helper/InPlaceEditingHelper.php
+++ b/View/Helper/InPlaceEditingHelper.php
@@ -33,12 +33,12 @@ class InPlaceEditingHelper extends AppHelper {
 		$containerType	= $this->__extractSetting($settings, 'containerType',	'div');
 
 		$script = "
-			<$containerType id=\"inplace_$fieldName\">$value</$containerType>
+			<$containerType id=\"inplace_$fieldName$id\">$value</$containerType>
 			<script type=\"text/javascript\">
 				$(
 					function()
 					{
-						$('#inplace_$fieldName').editable
+						$('#inplace_$fieldName$id').editable
 						(
 							'../$actionName/$id',
 							{


### PR DESCRIPTION
Concatenated $fieldName with $id to ensure HTML tags are unique when multiple records from the same field are output on the same page and made editable.

This is useful for example in situations, where a table holds labels in one column, and values in another. When these pairs are output on the page, there needs to be an additional distinction in the HTML ID attribute to make these tags unique.
