### PR TITLE
fix: generating element id

### DIFF
--- a/View/Helper/InPlaceEditingHelper.php
+++ b/View/Helper/InPlaceEditingHelper.php
@@ -33,12 +33,12 @@ class InPlaceEditingHelper extends AppHelper {
 		$containerType	= $this->__extractSetting($settings, 'containerType',	'div');
 
 		$script = "
-			<$containerType id=\"inplace_$fieldName$id\">$value</$containerType>
+			<$containerType id='inplace_".$modelName."_".$fieldName."_".$id."'>$value</$containerType>
 			<script type=\"text/javascript\">
 				$(
 					function()
 					{
-						$('#inplace_$fieldName$id').editable
+						$('#inplace_".$modelName."_".$fieldName."_".$id."').editable
 						(
 							'../$actionName/$id',
 							{


### PR DESCRIPTION
if you don't include model name in element #ID then the code will fail in situation when on one page you have InPlaceEditable form elements for two different models with same field name & id. Ex User.note & Profile.note. 

With old code we'll end up with sth like: #inplaceNote1 for both fields
With fix we'll have: #inplace_User_note_1 and #inplace_Profile_note_1